### PR TITLE
Set model attribute of genericAnswerIndexOffset

### DIFF
--- a/js/adapt-contrib-textInput.js
+++ b/js/adapt-contrib-textInput.js
@@ -15,6 +15,7 @@ define(function(require) {
         },
 
         setupQuestion: function() {
+            this.model.set( '_genericAnswerIndexOffset', genericAnswerIndexOffset );
             this.setupItemIndexes();
             this.restoreUserAnswer();
 


### PR DESCRIPTION
In order to have full access from any extensions, it would be useful to be able to have access to the genericAnswerIndexOffset variable.