### PR TITLE
Hook into _canShowMarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ guide the learner’s interaction with the component.
 
 **_canShowModelAnswer** (boolean): Setting this to `false` prevents the [**_showCorrectAnswer** button](https://github.com/adaptlearning/adapt_framework/wiki/Core-Buttons) from being displayed. The default is `true`.
 
+**_canShowMarking** (boolean): Setting this to `false` prevents ticks and crosses being displayed on question completion. The default is `true`.
+
 **_recordInteraction** (boolean) Determines whether or not the learner's answer(s) will be recorded on the LMS via cmi.interactions. Default is `true`. For further information, see the entry for `_shouldRecordInteractions` in the README for [adapt-contrib-spoor](https://github.com/adaptlearning/adapt-contrib-spoor).
 
 **_allowsAnyCase** (boolean): This setting determines whether or not the learner's input must match the uppercase and lowercase letters of the supplied answer/s. Set to `false` if case-sensitivity is required for a correct answer. The default is `true`.  

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-textInput",
   "version": "2.0.4",
-  "framework": "^2.0.0",
+  "framework": "^2.0.11",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-textInput",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-textInput%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20screenshots.",
   "description": "A question component that allows the learner to input text based upon a question stem.",

--- a/example.json
+++ b/example.json
@@ -15,6 +15,7 @@
     "_questionWeight":10,
     "_isRandom":false,
     "_canShowModelAnswer": true,
+    "_canShowMarking": true,
     "_recordInteraction": true,
     "_allowsAnyCase": true,
     "_allowsPunctuation": true,

--- a/js/adapt-contrib-textInput.js
+++ b/js/adapt-contrib-textInput.js
@@ -219,6 +219,8 @@ define(function(require) {
         // This is important and should give the user feedback on how they answered the question
         // Normally done through ticks and crosses by adding classes
         showMarking: function() {
+            if (!this.model.get('_canShowMarking')) return;
+
             _.each(this.model.get('_items'), function(item, i) {
                 var $item = this.$('.textinput-item').eq(i);
                 $item.removeClass('correct incorrect').addClass(item._isCorrect ? 'correct' : 'incorrect');

--- a/less/textinput.less
+++ b/less/textinput.less
@@ -85,7 +85,7 @@
         .textinput-select-icon {
             display: none;
         }
-        .textinput-correct-icon {
+        .correct .textinput-correct-icon {
             display: block;
         }
     }

--- a/properties.schema
+++ b/properties.schema
@@ -113,6 +113,14 @@
       "validators": [],
       "help": "Select 'true' to allow the user to view feedback on their answer"
     },
+    "_canShowMarking": {
+      "type": "boolean",
+      "default": true,
+      "title": "Display Marking",
+      "inputType": { "type": "Boolean", "options": [ true, false ] },
+      "validators": [],
+      "help": "Select 'true' to display ticks and crosses on question completion"
+    },
     "_shouldDisplayAttempts": {
       "type":"boolean",
       "required":false,

--- a/templates/textinput.hbs
+++ b/templates/textinput.hbs
@@ -4,7 +4,7 @@
     {{! complex unless and if combination to set the correct classes for CSS to use in showing marking and disabled states}}
     <div class="textinput-widget component-widget {{#unless _isEnabled}} disabled {{#if _isInteractionComplete}} complete submitted show-user-answer {{#if _isCorrect}}correct{{/if}} {{/if}} {{/unless}}">
         {{#each _items}}
-        <div class="textinput-item component-item component-item-color component-item-border clearfix {{#if prefix}}prefix{{/if}} {{#if suffix}}suffix{{/if}} {{#unless ../_isEnabled}}{{#if _isCorrect}}correct{{else}}incorrect{{/if}}{{/unless}}">
+        <div class="textinput-item component-item component-item-color component-item-border clearfix {{#if prefix}}prefix{{/if}} {{#if suffix}}suffix{{/if}} {{#unless ../_isEnabled}}{{#if ../_canShowMarking}}{{#if _isCorrect}}correct{{else}}incorrect{{/if}}{{/if}}{{/unless}}">
             {{#if prefix}}
                 <label class="textinput-item-prefix component-item-text-color" id="{{../../_id}}-{{@index}}-aria" for="{{../../_id}}-{{@index}}" aria-label="{{{prefix}}}">
                     {{{prefix}}}


### PR DESCRIPTION
Avoids adding correctness classes to items if `_canShowMarking` is false.

Please only merge once the new version of the framework has been released (v2.0.11).

Original issue: adaptlearning/adapt_framework#1046.