### PR TITLE
Updated feedback to show title independent of title/display title of the component.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ guide the learner’s interaction with the component.
 **_feedback** (object): If the [**Tutor** extension](https://github.com/adaptlearning/adapt-contrib-tutor) is enabled, these various texts will be displayed depending on the submitted answer. **_feedback**
 contains values for three types of answers: **correct**, **_incorrect**, and **_partlyCorrect**. Some attributes are optional. If they are not supplied, the default that is noted below will be used.
 
+>**title** (string): Text that will be displayed as the feedback title.
+
 >**correct** (string): Text that will be displayed when the submitted answer is correct.  
 
 >**_incorrect** (object): Texts that will be displayed when the submitted answer is incorrect. It contains values that are displayed under differing conditions: **final** and **notFinal**. 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ guide the learner’s interaction with the component.
 **_feedback** (object): If the [**Tutor** extension](https://github.com/adaptlearning/adapt-contrib-tutor) is enabled, these various texts will be displayed depending on the submitted answer. **_feedback**
 contains values for three types of answers: **correct**, **_incorrect**, and **_partlyCorrect**. Some attributes are optional. If they are not supplied, the default that is noted below will be used.
 
->**title** (string): Text that will be displayed as the feedback title.
+>**title** (string): If not set, the component's **displayTitle** is used as the feedback title. If **displayTitle** is not set , **title** will be used instead.
 
 >**correct** (string): Text that will be displayed when the submitted answer is correct.  
 

--- a/example.json
+++ b/example.json
@@ -50,6 +50,7 @@
       }
   ],
   "_feedback": {
+    "title": "Feedback title",
     "correct": "This feedback will appear if you answered the question correctly.",
     "_incorrect": {
       "notFinal": "",

--- a/example.json
+++ b/example.json
@@ -50,7 +50,7 @@
       }
   ],
   "_feedback": {
-    "title": "Feedback title",
+    "title": "Feedback",
     "correct": "This feedback will appear if you answered the question correctly.",
     "_incorrect": {
       "notFinal": "",

--- a/properties.schema
+++ b/properties.schema
@@ -176,6 +176,16 @@
       "required": false,
       "title": "Feedback",
       "properties": {
+        "title": {
+          "type": "string",
+          "required": false,
+          "default": "",
+          "title": "Feedback Title",
+          "inputType": "Text",
+          "validators": [],
+          "help": "This text will display as the feedback title",
+          "translatable": true
+        },
         "correct": {
           "type": "string",
           "required": false,

--- a/properties.schema
+++ b/properties.schema
@@ -183,7 +183,7 @@
           "title": "Feedback Title",
           "inputType": "Text",
           "validators": [],
-          "help": "This text will display as the feedback title",
+          "help": "Leave blank to have the component's title shown instead.",
           "translatable": true
         },
         "correct": {


### PR DESCRIPTION
Related to issue: adaptlearning/adapt_framework#1876
and PR: adaptlearning/adapt_framework#1954