### PR TITLE
issue/2802 Use placeholder as aria-label if prefix is undefined

### DIFF
--- a/templates/textinput.hbs
+++ b/templates/textinput.hbs
@@ -18,7 +18,7 @@
 
       {{#if ../_isEnabled}}
       <div class="textinput__item-textbox-container">
-        <input class="textinput__item-textbox js-textinput-textbox" type="text" placeholder="{{{placeholder}}}" data-id="input-{{@index}}" id="{{../_id}}-{{@index}}"  {{#if prefix}}aria-labelledby="{{../_id}}-{{@index}}-aria"{{else}}aria-label="{{{placeholder}}}"{{/if}} value="">
+        <input class="textinput__item-textbox js-textinput-textbox" type="text" placeholder="{{{placeholder}}}" data-id="input-{{@index}}" id="{{../_id}}-{{@index}}" {{#if prefix}}aria-labelledby="{{../_id}}-{{@index}}-aria"{{else}}aria-label="{{{placeholder}}}"{{/if}} value="">
 
         <div class="textinput__item-state">
           <div class="textinput__item-icon textinput__item-correct-icon">

--- a/templates/textinput.hbs
+++ b/templates/textinput.hbs
@@ -18,7 +18,7 @@
 
       {{#if ../_isEnabled}}
       <div class="textinput__item-textbox-container">
-        <input class="textinput__item-textbox js-textinput-textbox" type="text" placeholder="{{{placeholder}}}" data-id="input-{{@index}}" id="{{../_id}}-{{@index}}" aria-labelledby="{{../_id}}-{{@index}}-aria" value="">
+        <input class="textinput__item-textbox js-textinput-textbox" type="text" placeholder="{{{placeholder}}}" data-id="input-{{@index}}" id="{{../_id}}-{{@index}}"  {{#if prefix}}aria-labelledby="{{../_id}}-{{@index}}-aria"{{else}}aria-label="{{{placeholder}}}"{{/if}} value="">
 
         <div class="textinput__item-state">
           <div class="textinput__item-icon textinput__item-correct-icon">


### PR DESCRIPTION
[#2802](https://github.com/adaptlearning/adapt_framework/issues/2802)
* Use placeholder as aria-label if prefix is undefined so as not to have a floating `aria-labelledby` attribute