### PR TITLE
Fix: Add correct +/ incorrect aria labels to ticks and crosses (fixes #116)

### DIFF
--- a/templates/textinput.jsx
+++ b/templates/textinput.jsx
@@ -1,16 +1,14 @@
-import Adapt from 'core/js/adapt';
 import React from 'react';
 import { compile, classes, templates, html } from 'core/js/reactHelpers';
 
 export default function TextInput (props) {
-  const ariaLabels = Adapt.course.get('_globals')._accessibility._ariaLabels;
-
   const {
     _isInteractionComplete,
     _id,
     _isEnabled,
     _isCorrect,
-    _shouldShowMarking
+    _shouldShowMarking,
+    _globals
   } = props;
 
   return (
@@ -60,10 +58,10 @@ export default function TextInput (props) {
                 disabled={!_isEnabled}
               />
               <div className="textinput-item__state">
-                <div className="textinput-item__icon textinput-item__correct-icon" aria-label={ariaLabels.correct}>
+                <div className="textinput-item__icon textinput-item__correct-icon" aria-label={_globals._accessibility._ariaLabels.correct}>
                   <div className="icon" />
                 </div>
-                <div className="textinput-item__icon textinput-item__incorrect-icon" aria-label={ariaLabels.incorrect}>
+                <div className="textinput-item__icon textinput-item__incorrect-icon" aria-label={_globals._accessibility._ariaLabels.incorrect}>
                   <div className="icon" />
                 </div>
               </div>

--- a/templates/textinput.jsx
+++ b/templates/textinput.jsx
@@ -1,7 +1,10 @@
+import Adapt from 'core/js/adapt';
 import React from 'react';
 import { compile, classes, templates, html } from 'core/js/reactHelpers';
 
 export default function TextInput (props) {
+  const ariaLabels = Adapt.course.get('_globals')._accessibility._ariaLabels;
+
   const {
     _isInteractionComplete,
     _id,
@@ -57,10 +60,10 @@ export default function TextInput (props) {
                 disabled={!_isEnabled}
               />
               <div className="textinput-item__state">
-                <div className="textinput-item__icon textinput-item__correct-icon">
+                <div className="textinput-item__icon textinput-item__correct-icon" aria-label={ariaLabels.correct}>
                   <div className="icon" />
                 </div>
-                <div className="textinput-item__icon textinput-item__incorrect-icon">
+                <div className="textinput-item__icon textinput-item__incorrect-icon" aria-label={ariaLabels.incorrect}>
                   <div className="icon" />
                 </div>
               </div>


### PR DESCRIPTION
Fixes #116

### Fix
Adds aria-labels of Correct or Incorrect to the tick and cross icons

### Testing
1. Incorrectly complete a TextInput component
2. Toggle between Show Correct Answer and Show My Answer
3. With a screenreader, tab up to where the answer is shown and then to the tick/cross icon.

Relates to https://github.com/adaptlearning/adapt_framework/issues/2241

