### PR TITLE
Update: Remove ariaQuestion placeholder text (fixes #133)

### DIFF
--- a/example.json
+++ b/example.json
@@ -11,7 +11,7 @@
         "displayTitle": "Title of our text input component",
         "body": "If A is 1% and Z is 26%, what are B, C and D?",
         "instruction": "Input your answer and select Submit.",
-        "ariaQuestion": "Question text specifically for screen readers.",
+        "ariaQuestion": "",
         "_attempts": 1,
         "_shouldDisplayAttempts": false,
         "_isRandom": false,


### PR DESCRIPTION
Prevent placeholder text being copied over and left in accessible courses. Property description is noted in README and schema help/description for reference.

Fixes https://github.com/adaptlearning/adapt-contrib-textInput/issues/133

Missing `ariaQuestion` property added to [wiki](https://github.com/adaptlearning/adapt_framework/wiki/Core-model-attributes/_edit#question-model-attributes).