### PR TITLE
Fix: Compile prefix and suffix (fixes #135)

### DIFF
--- a/templates/textinput.jsx
+++ b/templates/textinput.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { classes, templates } from 'core/js/reactHelpers';
+import { classes, templates, compile } from 'core/js/reactHelpers';
 
 export default function TextInput (props) {
   const {
@@ -48,7 +48,7 @@ export default function TextInput (props) {
                   id={`${_id}-${index}-aria`}
                   htmlFor={`${_id}-${index}`}
                   aria-label={prefix}
-                  dangerouslySetInnerHTML={{ __html: prefix }}
+                  dangerouslySetInnerHTML={{ __html: compile(prefix, props) }}
                 >
                 </label>
               </div>
@@ -83,7 +83,7 @@ export default function TextInput (props) {
                   id={`${_id}-${index}-aria`}
                   htmlFor={`${_id}-${index}`}
                   aria-label={suffix}
-                  dangerouslySetInnerHTML={{ __html: suffix }}
+                  dangerouslySetInnerHTML={{ __html: compile(suffix, props) }}
                 >
                 </label>
               </div>


### PR DESCRIPTION
Fixes #135 

### Fix
* Compiles `prefix` and `suffix`

### Testing
For the `prefix` and `suffix` of an item, add the following:

```
{{a11y_alt_text '$5bn' 'five billion dollars'}}
```

The resulting HTML code should look like this:

```
<span aria-hidden="true">$5bn</span>
<span class="aria-label">five billion dollars</span>
```