### PR TITLE
Fix: Marking ticks and mixed configs (fixes #148)

### DIFF
--- a/js/textInputModel.js
+++ b/js/textInputModel.js
@@ -89,11 +89,8 @@ class TextInputModel extends QuestionModel {
   }
 
   isCorrect() {
-    if (this.get('_answers')) {
-      this.markGenericAnswers();
-    } else {
-      this.markSpecificAnswers();
-    }
+    this.markGenericAnswers();
+    this.markSpecificAnswers();
     return this.get('_items').every(({ _isCorrect }) => _isCorrect);
   }
 
@@ -109,6 +106,8 @@ class TextInputModel extends QuestionModel {
     const usedAnswerIndexes = [];
 
     this.get('_items').forEach(item => {
+      const hasItemAnswers = Boolean(item._answers?.length);
+      if (hasItemAnswers) return;
       correctAnswers.forEach((answerGroup, answerIndex) => {
         if (usedAnswerIndexes.includes(answerIndex)) return;
 
@@ -133,8 +132,9 @@ class TextInputModel extends QuestionModel {
   markSpecificAnswers() {
     let numberOfCorrectAnswers = 0;
     this.get('_items').forEach(item => {
+      const hasItemAnswers = Boolean(item._answers?.length);
+      if (!hasItemAnswers) return;
       const answers = item._answers;
-      if (!answers) return;
       const userAnswer = item.userAnswer || '';
       const isCorrect = this.checkAnswerIsCorrect(answers, userAnswer);
       item._isCorrect = isCorrect;

--- a/templates/textinput.jsx
+++ b/templates/textinput.jsx
@@ -33,7 +33,7 @@ export default function TextInput (props) {
         role='group'
       >
 
-        {props._items.map(({ prefix, _index, input, placeholder, userAnswer, suffix }, index) =>
+        {props._items.map(({ prefix, _index, input, placeholder, userAnswer, suffix, _isCorrect }, index) =>
 
           <div
             className={classes([


### PR DESCRIPTION
fixes #148 

### Fix
* Marking ticks and mixed configs


### Testing
```json
"_answers": [
        ["alpha", "a"],
        ["beta", "b"],
        ["gamma"],
        ["delta", "d"]
    ],
    "_items": [
      {
        "prefix": "pref1",
        "suffix": "suff1",
        "placeholder": "Enter answer here1"
      },
      {
        "prefix": "pref2",
        "suffix": "suff2",
        "placeholder": "Enter answer here2"
      },
      {
        "_answers": [
          "tom",
          "t"
        ],
        "prefix": "pref3",
        "suffix": "suff3",
        "placeholder": "Enter answer here3"
      },
      {
        "prefix": "pref4",
        "suffix": "suff4",
        "placeholder": "Enter answer here4"
      }
    ],
```
Should show image below (minus correct answer display):
![image](https://github.com/user-attachments/assets/0bf092f6-d3b6-467e-bb76-173a6fa00efd)
