### PR TITLE
Fix: validate all textinput items in e2e test (fixes #163)

### DIFF
--- a/test/e2e/textInput.cy.js
+++ b/test/e2e/textInput.cy.js
@@ -13,10 +13,11 @@ describe('Text Input', function () {
       cy.testContainsOrNotExists('.textinput__title', stripHtml(textInputComponent.displayTitle));
       cy.testContainsOrNotExists('.textinput__instruction', stripHtml(textInputComponent.instruction));
 
-      cy.get('.textinput-item__textbox').should('have.length', 1);
-      if (textInputComponent._items[0].placeholder) {
-        cy.get('.textinput-item__textbox').should('have.attr', 'placeholder', textInputComponent._items[0].placeholder);
-      };
+      cy.get('.textinput-item__textbox').should('have.length', textInputComponent._items.length);
+      textInputComponent._items.forEach((item, index) => {
+        if (!item.placeholder) return;
+        cy.get('.textinput-item__textbox').eq(index).should('have.attr', 'placeholder', item.placeholder);
+      });
 
       // Make sure the current component is tested before moving to the next one
       // Custom cypress tests are async so we need to wait for them to pass first


### PR DESCRIPTION
Fixes #163

### Fix
The e2e test "should display the text input component" assumed each textinput component had exactly one textbox. It asserted `.textinput-item__textbox` had a length of `1` and only checked the placeholder on the first item. Components with multiple `_items` failed the length assertion, and any additional items were never validated.

The test now asserts the textbox count matches `_items.length` and loops over every item to check each placeholder.

### Testing
1. Build a course containing a textinput component with multiple `_items` (each with a `placeholder`).
2. Run the framework e2e suite (`npm test e2e`) against that build.
3. The "should display the text input component" test should pass and validate every textbox, not just the first.

Posted via collaboration with Claude Code
